### PR TITLE
Add copy to clipboard functionality for QR code links in dashboard #12

### DIFF
--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -223,7 +223,13 @@ const Dashboard = () => {
                     </td>
                     <td className="px-6 py-4 max-w-xs">
                       <div className="relative group">
-                        <div className="truncate hover:text-gray-300 cursor-pointer">
+                        <div 
+                          className="truncate hover:text-gray-300 cursor-pointer"
+                          onClick={() => {
+                            navigator.clipboard.writeText(item.data);
+                            toast("Link copied to clipboard!");
+                          }}
+                        >
                           {item.data}
                         </div>
                         {/* Tooltip */}


### PR DESCRIPTION
- Adds a copy to clipboard feature for QR code links in the dashboard, enhancing user experience by allowing quick access to links with a toast notification confirmation.